### PR TITLE
Keep mods dir and add .gitkeep file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # module output directory
 mods
+!mods/.gitkeep
 
 # IntelliJ
 .idea

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ Also see:
 
 Below is an outline of the chapter and the commands. Note that in this github repo, the commands are one line so you can copy/paste them into your command line. In the book, we used multiple lines for ease in reading/studying.
 
-Note: You may have to create the "mods" directory before running depending on your OS
-
 # Creating and Running a Modular Program
 ## Creating the Files
 See the feeding folder for module zoo.animal.feeding

--- a/mods/.gitkeep
+++ b/mods/.gitkeep
@@ -1,0 +1,1 @@
+This file prevents the mods dir to be removed.


### PR DESCRIPTION
In the [.gitignore](https://github.com/boyarsky/sybex-1Z0-815-chapter-11/blob/master/.gitignore) file also the `mods` directory has been ignored. However the commands rely on the existence of a `mods` directory, so to ignore the whole directory might be too much.

My proposal would be to add a `.gitkeep` file in the `mods` folder. So it remains visible in git (empty folders will be ignored automatically). The files within the mods folder will remain to be ignored (except for the `.gitkeep` file). 

Since this change won't need to create the mods folder anymore, also the Readme file has been updated.